### PR TITLE
Firefox対応

### DIFF
--- a/app/views/code/index.js
+++ b/app/views/code/index.js
@@ -215,7 +215,13 @@ module.exports = BaseView.extend({
   // see also: http://stackoverflow.com/a/14284215
   tick: function(file) {
     var that = this;
-    if (file && file.lastModifiedDate.getTime() != that.lastMod.getTime()) {
+    if (!file) {
+      return;
+    }
+    if (that.isFirefox()) {
+      // Firefoxだと更新日時が変わらないため常にファイルを読み込む
+      that.reader.readAsText(file);
+    } else if (file.lastModifiedDate.getTime() != that.lastMod.getTime()) {
       that.lastMod = file.lastModifiedDate;
       that.reader.readAsText(file);
     }
@@ -228,6 +234,13 @@ module.exports = BaseView.extend({
       return true;
     }
     return false;
+  },
+
+  /*
+   * Firefoxか？
+   */
+  isFirefox: function() {
+    return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
   },
 
   /*


### PR DESCRIPTION
Firefoxだと`file.lastModifiedDate`が更新されない問題の対応(#30)。
Firefoxの場合だけ常にFileを読み込む(ただしDiffがない場合は保存処理は行われない)
