### PR TITLE
Travis-CIで稼働する際のnodeのバージョンを0.10系で固定

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.11.11"
+  - "0.10.28"


### PR DESCRIPTION
### 解決したいこと
- Travis-CIで動かす際のnodeのバージョンを0.10.28で固定します。
