### PR TITLE
デプロイ時に利用するnpmホストを変更

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,7 +43,7 @@ namespace :rendr do
     queue 'echo "-----> Start npm install tasks."'
     queue! %{
       cd #{deploy_to}/current
-      npm install
+      npm install --registry http://10.0.3.14:10080/
     }
   end
 


### PR DESCRIPTION
### 解決したいこと
- デプロイの際に利用するnpmレジストリを同一ホスト内の別コンテナに設けたホストを参照する様にします
