### PR TITLE
json内にscriptタグが含まれる場合のエラーを回避する

### DIFF
--- a/app/lib/handlebarsHelpers.js
+++ b/app/lib/handlebarsHelpers.js
@@ -6,6 +6,10 @@ module.exports = function(Handlebars) {
   return {
     copyright: function(year) {
       return new Handlebars.SafeString("&copy;" + year);
+    },
+    unescape: function(context) {
+      var html = context.replace(/<\\\//g, '</');
+      return html;
     }
   };
 };

--- a/app/templates/code/index.hbs
+++ b/app/templates/code/index.hbs
@@ -1,6 +1,6 @@
 <div id="content">
   {{#if body}}
-  <div id="editor">{{body}}</div>
+  <div id="editor">{{unescape body}}</div>
   {{else}}
   <div id="editor">
        ______                  __

--- a/app/views/code/index.js
+++ b/app/views/code/index.js
@@ -308,6 +308,11 @@ module.exports = BaseView.extend({
    */
   preRender: function() {
     console.log("--- preRender");
+    if (this.model.get('body')) {
+      var code = this.model.get('body');
+      code = code.replace(/<\//g, '<\\/');
+      this.model.set('body', code);
+    }
   },
 
   /*


### PR DESCRIPTION
@hideack
- json内にscriptタグが含まれる場合にサーバーサイドでエスケープする
- 出力時はテンプレ側でエスケープを戻す(Aceに渡す前に)
